### PR TITLE
[feat] Support retention durations

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -11,7 +11,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@coinbase/cookie-banner": "1.0.1",
+    "@coinbase/cookie-banner": "1.0.2",
     "@coinbase/cookie-manager": "1.1.0",
     "next": "14.0.0",
     "react": "^18",

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@coinbase/cookie-banner": "1.0.1",
-    "@coinbase/cookie-manager": "^1.0.0",
+    "@coinbase/cookie-manager": "1.1.0",
     "next": "14.0.0",
     "react": "^18",
     "react-dom": "^18"

--- a/apps/example/pages/_app.tsx
+++ b/apps/example/pages/_app.tsx
@@ -9,11 +9,12 @@ import { cookieManagerConfig } from '../utils/cookieManagerConfig';
 
 export default function App({ Component, pageProps }: AppProps) {
   const [isMounted, setIsMounted] = useState(false);
+  const trackingPreference = useRef<TrackingPreference | undefined>();
+
   useEffect(() => {
     setIsMounted(true);
   }, []);
 
-  const trackingPreference = useRef<TrackingPreference | undefined>();
   const setTrackingPreference = useCallback((newPreference: TrackingPreference) => {
     const priorConsent = trackingPreference.current?.consent;
     trackingPreference.current = newPreference;
@@ -38,6 +39,7 @@ export default function App({ Component, pageProps }: AppProps) {
       window.location.reload();
     }
   }, []);
+
   if (!isMounted) return null;
 
   return (
@@ -45,7 +47,7 @@ export default function App({ Component, pageProps }: AppProps) {
       onError={console.error}
       projectName="test"
       locale="en"
-      region={Region.EU}
+      region={Region.DEFAULT}
       config={cookieManagerConfig}
       log={console.log}
       onPreferenceChange={setTrackingPreference}

--- a/apps/example/pages/index.tsx
+++ b/apps/example/pages/index.tsx
@@ -1,11 +1,24 @@
 import { CookieBanner } from '@coinbase/cookie-banner';
+import { useCookie } from '@coinbase/cookie-manager';
 import { Inter } from 'next/font/google';
+import { useEffect } from 'react';
 
 import useTranslations from '@/hooks/useTranslations';
 
 const inter = Inter({ subsets: ['latin'] });
 
 export default function Home() {
+  const [, setIpCountryCookie] = useCookie('ip_country');
+  const [, setLocaleCookie] = useCookie('locale');
+  const [, setRFMCookie] = useCookie('rfm');
+  const [trackingPreference] = useCookie('cm_eu_preference');
+
+  useEffect(() => {
+    setIpCountryCookie('US');
+    setRFMCookie('locale');
+    setLocaleCookie('en');
+  }, [setIpCountryCookie, setLocaleCookie, setRFMCookie, trackingPreference]);
+
   return (
     <main className={`flex min-h-screen bg-black justify-end flex-col ${inter.className}`}>
       <CookieBanner

--- a/apps/example/utils/cookieManagerConfig.ts
+++ b/apps/example/utils/cookieManagerConfig.ts
@@ -9,6 +9,11 @@ export const cookieManagerConfig = {
         {
           id: 'ip_country',
           type: TrackerType.COOKIE,
+          expiry: new Date('2024-09-29T00:00:00.000Z'),
+        },
+        {
+          id: 'locale',
+          type: TrackerType.COOKIE,
         },
       ],
     },
@@ -16,8 +21,9 @@ export const cookieManagerConfig = {
       id: TrackingCategory.PERFORMANCE,
       trackers: [
         {
-          id: 'cb-rfm',
+          id: 'rfm',
           type: TrackerType.COOKIE,
+          sessionCookie: true,
         },
       ],
     },

--- a/apps/example/utils/cookieManagerConfig.ts
+++ b/apps/example/utils/cookieManagerConfig.ts
@@ -4,12 +4,13 @@ export const cookieManagerConfig = {
   categories: [
     {
       id: TrackingCategory.NECESSARY,
+      expiry: 365,
       required: true,
       trackers: [
         {
           id: 'ip_country',
           type: TrackerType.COOKIE,
-          expiry: new Date('2024-09-29T00:00:00.000Z'),
+          expiry: 10,
         },
         {
           id: 'locale',
@@ -19,6 +20,7 @@ export const cookieManagerConfig = {
     },
     {
       id: TrackingCategory.PERFORMANCE,
+      expiry: 365,
       trackers: [
         {
           id: 'rfm',
@@ -29,6 +31,7 @@ export const cookieManagerConfig = {
     },
     {
       id: TrackingCategory.FUNCTIONAL,
+      expiry: 365,
       trackers: [
         {
           id: 'mode',
@@ -38,6 +41,7 @@ export const cookieManagerConfig = {
     },
     {
       id: TrackingCategory.TARGETING,
+      expiry: 365,
       trackers: [
         {
           id: 'gclid',
@@ -47,6 +51,7 @@ export const cookieManagerConfig = {
     },
     {
       id: TrackingCategory.DELETE_IF_SEEN,
+      expiry: 0,
       trackers: [
         {
           id: 'challenge-regex',

--- a/packages/cookie-banner/CHANGELOG.md
+++ b/packages/cookie-banner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.2 (12/11/2023 PST)
+
+#### Chore
+
+- Update the cookie manager version and fix Close Icon styling
+
 ## 1.0.1 (12/11/2023 PST)
 
 #### 🐞 Fixes

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -201,4 +201,4 @@ The returned record should contain all the keys mentioned in this example. All t
 
 ## License
 
-Licensed under the Apache License. See [LICENSE](./LICENSE) for more information.
+Licensed under the Apache License. See [LICENSE](./LICENSE.md) for more information.

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -18,7 +18,8 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "rimraf": "^5.0.5",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "wrap-ansi": "^7.0.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cookie-banner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "license": "Apache-2.0",
   "scripts": {
@@ -26,7 +26,7 @@
     "react-dom": "^18.1.0"
   },
   "dependencies": {
-    "@coinbase/cookie-manager": "^1.0.0",
+    "@coinbase/cookie-manager": "1.1.0",
     "react-intl": "^6.5.1",
     "styled-components": "^5.3.6"
   }

--- a/packages/cookie-banner/src/components/CookieBannerContent.tsx
+++ b/packages/cookie-banner/src/components/CookieBannerContent.tsx
@@ -126,8 +126,9 @@ const MobileDismissButton = styled(DismissButton)`
 `;
 
 const DesktopDismissButton = styled(DismissButton)`
+  display: flex;
   @media (max-width: ${({ theme }) => theme.breakpoints.tablet}px) {
-    display: flex;
+    display: none;
   }
 `;
 

--- a/packages/cookie-banner/src/examples/config.ts
+++ b/packages/cookie-banner/src/examples/config.ts
@@ -4,6 +4,7 @@ export default {
   categories: [
     {
       id: TrackingCategory.NECESSARY,
+      expiry: 365,
       required: true,
       trackers: [
         {
@@ -14,6 +15,7 @@ export default {
     },
     {
       id: TrackingCategory.PERFORMANCE,
+      expiry: 365,
       trackers: [
         {
           id: 'some_cookie',
@@ -31,6 +33,7 @@ export default {
     },
     {
       id: TrackingCategory.FUNCTIONAL,
+      expiry: 365,
       trackers: [
         {
           id: 'mode',
@@ -40,6 +43,7 @@ export default {
     },
     {
       id: TrackingCategory.TARGETING,
+      expiry: 365,
       trackers: [
         // First party
         {
@@ -55,6 +59,7 @@ export default {
     },
     {
       id: TrackingCategory.DELETE_IF_SEEN,
+      expiry: 0,
       trackers: [
         {
           id: 'cgl_prog',

--- a/packages/cookie-manager/CHANGELOG.md
+++ b/packages/cookie-manager/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 1.1.0 (12/14/2023)
 
-Support retention durations for Cookies in the config and category level
+- Updated cookie config to include retention durations at both category and cookie levels.
+- Introduced an optional boolean field `sessionCookie` in cookie config to accommodate session cookies.
+- Implemented a setExpiryForCookie hook that adjusts the cookie's expiration in the following manner:
+  - If the sessionCookie parameter is enabled, the expiry is set to session
+  - If an expiry is specified at the cookie level, it takes precedence; otherwise, the expiry is derived from the category's expiration setting.
 
 ## 1.0.0 (12/7/2023)
 

--- a/packages/cookie-manager/CHANGELOG.md
+++ b/packages/cookie-manager/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 1.0.0 (12/7/2023 PST)
+## 1.1.0 (12/14/2023)
+
+Support retention durations for Cookies in the config and category level
+
+## 1.0.0 (12/7/2023)
 
 #### 🚀 Updates
 

--- a/packages/cookie-manager/README.md
+++ b/packages/cookie-manager/README.md
@@ -4,8 +4,8 @@
 
 # Contents
 
-- [Introduction](#Introduction)
 - [Installation](#installation)
+- [Introduction](#Introduction)
 - [Methods](#methods)
   - [Provider](#provider)
   - [useCookie](#usecookie)
@@ -19,6 +19,18 @@
   - [useTrackingManager](#usetrackingmanager)
   - [isOptOut](#isoptout)
 - [License](#license)
+
+## Installation
+
+Install the package as follows:
+
+```shell
+yarn add @coinbase/cookie-manager
+
+npm install @coinbase/cookie-manager
+
+pnpm install @coinbase/cookie-manager
+```
 
 ## Introduction
 
@@ -132,18 +144,6 @@ You can also specify regex for a given cookie as follows:
 Any id with `-regex` at the end should contain a `regex` which will be used to match different cookies.
 
 In this example: `id_ac7a5c3da45e3612b44543a702e42b01` will also be allowed
-
-## Installation
-
-Install the package as follows:
-
-```shell
-yarn add @coinbase/cookie-manager
-
-npm install @coinbase/cookie-manager
-
-pnpm install @coinbase/cookie-manager
-```
 
 ## Methods
 
@@ -476,4 +476,4 @@ const SomeComponent = () => {
 
 ## License
 
-Licensed under the Apache License. See [LICENSE](./LICENSE) for more information.
+Licensed under the Apache License. See [LICENSE](./LICENSE.md) for more information.

--- a/packages/cookie-manager/README.md
+++ b/packages/cookie-manager/README.md
@@ -74,7 +74,7 @@ export default {
         {
           id: 'locale',
           type: TrackerType.COOKIE,
-          expiry: new Date('2024-09-29T00:00:00.000Z'),
+          expiry: 10,
         },
       ],
     },
@@ -163,7 +163,7 @@ You need to specify the retention days for a category using the expiry key as fo
         {
           id: 'locale',
           type: TrackerType.COOKIE,
-          expiry: new Date('2024-09-29T00:00:00.000Z'),
+          expiry: 10,
         },
       ],
     }

--- a/packages/cookie-manager/README.md
+++ b/packages/cookie-manager/README.md
@@ -69,6 +69,7 @@ export default {
     {
       id: TrackingCategory.NECESSARY,
       required: true,
+      expiry: 365,
       trackers: [
         {
           id: 'locale',
@@ -79,6 +80,7 @@ export default {
     },
     {
       id: TrackingCategory.PERFORMANCE,
+      expiry: 365,
       trackers: [
         {
           id: 'some_cookie',
@@ -89,6 +91,7 @@ export default {
     },
     {
       id: TrackingCategory.FUNCTIONAL,
+      expiry: 365,
       trackers: [
         {
           id: 'mode',
@@ -98,6 +101,7 @@ export default {
     },
     {
       id: TrackingCategory.TARGETING,
+      expiry: 365,
       trackers: [
         {
           id: 'id-regex',
@@ -108,6 +112,7 @@ export default {
     },
     {
       id: TrackingCategory.DELETE_IF_SEEN,
+      expiry: 0,
       trackers: [
         {
           id: 'cgl_prog',
@@ -129,7 +134,7 @@ export default {
 };
 ```
 
-In this config, under each category you can specify what all cookies should be allowed. Everything else, if detected will be deleted at an interval of 500 ms.
+In this config, under each category you can specify what all cookies that should be allowed. Everything else, if detected will be deleted at an interval of 500 ms.
 
 `DELETE_IF_SEEN` can be used to specify the cookies which should be deleted if seen on the browser
 
@@ -147,13 +152,31 @@ Any id with `-regex` at the end should contain a `regex` which will be used to m
 
 In this example: `id_ac7a5c3da45e3612b44543a702e42b01` will also be allowed.
 
-Each cookie by default has an expiry of 1 year but you can also override this by specifying an expiry for the cookie within the config:
+You need to specify the retention days for a category using the expiry key as follows:
+
+```
+{
+      id: TrackingCategory.NECESSARY,
+      required: true,
+      expiry: 365,
+      trackers: [
+        {
+          id: 'locale',
+          type: TrackerType.COOKIE,
+          expiry: new Date('2024-09-29T00:00:00.000Z'),
+        },
+      ],
+    }
+
+```
+
+Each cookie by default will inherit its category's retention duration but you can override this by specifying an expiry (in days) for the cookie:
 
 ```
  {
     id: 'locale',
     type: TrackerType.COOKIE,
-    expiry: new Date('2024-09-29T00:00:00.000Z')
+    expiry: 10
 }
 ```
 
@@ -166,6 +189,8 @@ If you want a cookie to only be valid for a session, it can optionally be marked
   sessionCookie: true
 }
 ```
+
+**Note: Session cookies only last as long as your browser is open and are automatically deleted when a user closes the browser**
 
 ## Methods
 

--- a/packages/cookie-manager/README.md
+++ b/packages/cookie-manager/README.md
@@ -73,6 +73,7 @@ export default {
         {
           id: 'locale',
           type: TrackerType.COOKIE,
+          expiry: new Date('2024-09-29T00:00:00.000Z'),
         },
       ],
     },
@@ -82,6 +83,7 @@ export default {
         {
           id: 'some_cookie',
           type: TrackerType.COOKIE,
+          sessionCookie: true,
         },
       ],
     },
@@ -143,7 +145,27 @@ You can also specify regex for a given cookie as follows:
 
 Any id with `-regex` at the end should contain a `regex` which will be used to match different cookies.
 
-In this example: `id_ac7a5c3da45e3612b44543a702e42b01` will also be allowed
+In this example: `id_ac7a5c3da45e3612b44543a702e42b01` will also be allowed.
+
+Each cookie by default has an expiry of 1 year but you can also override this by specifying an expiry for the cookie within the config:
+
+```
+ {
+    id: 'locale',
+    type: TrackerType.COOKIE,
+    expiry: new Date('2024-09-29T00:00:00.000Z')
+}
+```
+
+If you want a cookie to only be valid for a session, it can optionally be marked as a session cookie as follows:
+
+```
+{
+  id: 'some_cookie',
+  type: TrackerType.COOKIE,
+  sessionCookie: true
+}
+```
 
 ## Methods
 

--- a/packages/cookie-manager/package.json
+++ b/packages/cookie-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cookie-manager",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Coinbase Cookie Manager",
   "main": "dist/index.js",
   "license": "Apache-2.0",
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@testing-library/react": "^14.1.1",
     "@types/jest": "^29.5.8",
     "@types/js-cookie": "^3.0.5",
     "@types/node": "^20.8.9",
@@ -21,9 +22,12 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
-    "@testing-library/react": "^14.1.1"
+    "wrap-ansi": "^7.0.0",
+    "wrap-ansi-cjs": "7.0.0"
   },
   "dependencies": {
+    "@coinbase/cookie-banner": "1.0.1",
+    "@coinbase/cookie-manager": "1.1.0",
     "js-cookie": "^3.0.5"
   }
 }

--- a/packages/cookie-manager/src/CookieContext.tsx
+++ b/packages/cookie-manager/src/CookieContext.tsx
@@ -25,6 +25,7 @@ import { getDomainWithoutSubdomain, getHostname } from './utils/getDomain';
 import getTrackerInfo from './utils/getTrackerInfo';
 import hasConsent from './utils/hasConsent';
 import isMaxKBSize from './utils/isMaxKBSize';
+import setExpiryForCookie from './utils/setExpiryForCookie';
 import setGTMVariables from './utils/setGTMVariables';
 
 type CookieCache = Record<string, any>;
@@ -161,10 +162,18 @@ const setCookieFunction = ({
       if (isMaxKBSize(encodeURIComponent(stringValue) + cookieName, cookieSize)) {
         onError(new Error(`${cookieName} value exceeds ${cookieSize}KB`));
       } else {
-        const newOptions = options ? { ...options } : undefined;
+        let newOptions = options ? { ...options } : undefined;
 
         if (newOptions?.size) {
           delete newOptions.size;
+        }
+        const expiration = setExpiryForCookie(cookieName, config) as number | Date | undefined;
+        if (expiration) {
+          if (newOptions) {
+            newOptions = { ...newOptions, expires: expiration };
+          } else {
+            newOptions = { expires: expiration };
+          }
         }
         Cookies.set(cookieName, stringValue, newOptions);
       }

--- a/packages/cookie-manager/src/constants.ts
+++ b/packages/cookie-manager/src/constants.ts
@@ -34,11 +34,3 @@ export const TRACKER_CATEGORIES: Array<TrackingCategory> = [
   TrackingCategory.PERFORMANCE,
   TrackingCategory.TARGETING,
 ];
-
-export const CATEGORY_EXPIRATION_DAYS: Record<TrackingCategory, number> = {
-  [TrackingCategory.NECESSARY]: 365,
-  [TrackingCategory.FUNCTIONAL]: 365,
-  [TrackingCategory.PERFORMANCE]: 365,
-  [TrackingCategory.TARGETING]: 365,
-  [TrackingCategory.DELETE_IF_SEEN]: 0,
-};

--- a/packages/cookie-manager/src/constants.ts
+++ b/packages/cookie-manager/src/constants.ts
@@ -4,6 +4,7 @@ export const EU_CONSENT_PREFERENCES_COOKIE = 'cm_eu_preferences';
 export const DEFAULT_CONSENT_PREFERENCES_COOKIE = 'cm_default_preferences';
 export const ADVERTISING_SHARING_ALLOWED = 'advertising_sharing_allowed';
 export const IS_MOBILE_APP = 'is_mobile_app';
+export const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 
 export const GEOLOCATION_RULES: Array<GeolocationRule> = [
   {

--- a/packages/cookie-manager/src/constants.ts
+++ b/packages/cookie-manager/src/constants.ts
@@ -33,3 +33,11 @@ export const TRACKER_CATEGORIES: Array<TrackingCategory> = [
   TrackingCategory.PERFORMANCE,
   TrackingCategory.TARGETING,
 ];
+
+export const CATEGORY_EXPIRATION_DAYS: Record<TrackingCategory, number> = {
+  [TrackingCategory.NECESSARY]: 365,
+  [TrackingCategory.FUNCTIONAL]: 365,
+  [TrackingCategory.PERFORMANCE]: 365,
+  [TrackingCategory.TARGETING]: 365,
+  [TrackingCategory.DELETE_IF_SEEN]: 0,
+};

--- a/packages/cookie-manager/src/examples/config.ts
+++ b/packages/cookie-manager/src/examples/config.ts
@@ -4,6 +4,7 @@ export default {
   categories: [
     {
       id: TrackingCategory.NECESSARY,
+      expiry: 365,
       required: true,
       trackers: [
         {
@@ -13,12 +14,13 @@ export default {
         {
           id: 'test',
           type: TrackerType.COOKIE,
-          expiry: new Date('2038-01-01T00:00:00.000Z'),
+          expiry: 10,
         },
       ],
     },
     {
       id: TrackingCategory.PERFORMANCE,
+      expiry: 365,
       trackers: [
         {
           id: 'some_cookie',
@@ -36,6 +38,7 @@ export default {
     },
     {
       id: TrackingCategory.FUNCTIONAL,
+      expiry: 365,
       trackers: [
         {
           id: 'mode',
@@ -47,6 +50,7 @@ export default {
     },
     {
       id: TrackingCategory.TARGETING,
+      expiry: 365,
       trackers: [
         {
           id: 'gclid',
@@ -61,6 +65,7 @@ export default {
     },
     {
       id: TrackingCategory.DELETE_IF_SEEN,
+      expiry: 0,
       trackers: [
         {
           id: 'cgl_prog',

--- a/packages/cookie-manager/src/examples/config.ts
+++ b/packages/cookie-manager/src/examples/config.ts
@@ -10,6 +10,11 @@ export default {
           id: 'locale',
           type: TrackerType.COOKIE,
         },
+        {
+          id: 'test',
+          type: TrackerType.COOKIE,
+          expiry: new Date('2038-01-01T00:00:00.000Z'),
+        },
       ],
     },
     {
@@ -36,6 +41,7 @@ export default {
           id: 'mode',
           // Used to remember if the user dismissed the Advanced mode NUX modal
           type: TrackerType.COOKIE,
+          sessionCookie: true,
         },
       ],
     },

--- a/packages/cookie-manager/src/types.ts
+++ b/packages/cookie-manager/src/types.ts
@@ -43,13 +43,14 @@ export type Tracker = {
   type: TrackerType;
   sessionCookie?: boolean;
   regex?: string;
-  expiry?: Date;
+  expiry?: number;
 };
 
 export type ConfigCategoryInfo = {
   id: TrackingCategory;
   trackers: Array<Tracker>;
   required?: boolean;
+  expiry: number;
 };
 
 export type Config = {

--- a/packages/cookie-manager/src/types.ts
+++ b/packages/cookie-manager/src/types.ts
@@ -42,6 +42,7 @@ export type Tracker = {
   id: string;
   type: TrackerType;
   regex?: string;
+  expiry?: Date;
 };
 
 export type ConfigCategoryInfo = {

--- a/packages/cookie-manager/src/types.ts
+++ b/packages/cookie-manager/src/types.ts
@@ -41,6 +41,7 @@ export enum TrackerType {
 export type Tracker = {
   id: string;
   type: TrackerType;
+  sessionCookie?: boolean;
   regex?: string;
   expiry?: Date;
 };

--- a/packages/cookie-manager/src/utils/setExpiryForCookie.test.ts
+++ b/packages/cookie-manager/src/utils/setExpiryForCookie.test.ts
@@ -1,0 +1,19 @@
+import config from '../examples/config';
+import setExpiryForCookie from './setExpiryForCookie';
+
+describe('setExpiryForCookie', () => {
+  it('returns undefined when no cookie config is found', () => {
+    expect(setExpiryForCookie('cookieName', config)).toEqual(undefined);
+  });
+  it('returns expiry when cookie config has an expiry', () => {
+    expect(setExpiryForCookie('cookieName', config)).toEqual({
+      expires: new Date('2038-01-01T00:00:00.000Z'),
+    });
+  });
+  it('returns expiry when cookie is in a category with an expiry', () => {
+    const expiration = new Date();
+    expect(setExpiryForCookie('cookieName', config)).toEqual({
+      expires: expiration.getDate() + 365,
+    });
+  });
+});

--- a/packages/cookie-manager/src/utils/setExpiryForCookie.test.ts
+++ b/packages/cookie-manager/src/utils/setExpiryForCookie.test.ts
@@ -6,14 +6,14 @@ describe('setExpiryForCookie', () => {
     expect(setExpiryForCookie('cookieName', config)).toEqual(undefined);
   });
   it('returns expiry when cookie config has an expiry', () => {
-    expect(setExpiryForCookie('cookieName', config)).toEqual({
-      expires: new Date('2038-01-01T00:00:00.000Z'),
-    });
+    expect(setExpiryForCookie('test', config)).toEqual(new Date('2038-01-01T00:00:00.000Z'));
   });
   it('returns expiry when cookie is in a category with an expiry', () => {
     const expiration = new Date();
-    expect(setExpiryForCookie('cookieName', config)).toEqual({
-      expires: expiration.getDate() + 365,
-    });
+    expiration.setDate(expiration.getDate() + 365);
+    expect(setExpiryForCookie('some_cookie', config)).toEqual(expiration);
+  });
+  it('returns undefined when cookie is a session cookie', () => {
+    expect(setExpiryForCookie('mode', config)).toEqual(undefined);
   });
 });

--- a/packages/cookie-manager/src/utils/setExpiryForCookie.test.ts
+++ b/packages/cookie-manager/src/utils/setExpiryForCookie.test.ts
@@ -6,7 +6,9 @@ describe('setExpiryForCookie', () => {
     expect(setExpiryForCookie('cookieName', config)).toEqual(undefined);
   });
   it('returns expiry when cookie config has an expiry', () => {
-    expect(setExpiryForCookie('test', config)).toEqual(new Date('2038-01-01T00:00:00.000Z'));
+    const expiration = new Date();
+    expiration.setDate(expiration.getDate() + 10);
+    expect(setExpiryForCookie('test', config)).toEqual(expiration);
   });
   it('returns expiry when cookie is in a category with an expiry', () => {
     const expiration = new Date();

--- a/packages/cookie-manager/src/utils/setExpiryForCookie.ts
+++ b/packages/cookie-manager/src/utils/setExpiryForCookie.ts
@@ -14,10 +14,17 @@ const setExpiryForCookie = (cookieName: string, config: Config) => {
     trackerMatches(tracker, cookieName)
   );
 
+  if (!cookieConfig) {
+    return undefined;
+  }
+
+  // if its a session cookie, do not set an expiry
+  if (cookieConfig && cookieConfig.sessionCookie) {
+    return undefined;
+  }
+
   if (cookieConfig && cookieConfig.expiry) {
-    return {
-      expires: cookieConfig.expiry,
-    };
+    return cookieConfig.expiry;
   }
   // if cookie is in a category with an expiry, set the expiry to that
   const trackingCategoryExpiration = CATEGORY_EXPIRATION_DAYS[trackingCategory.id];
@@ -26,9 +33,7 @@ const setExpiryForCookie = (cookieName: string, config: Config) => {
   }
   const expiration = new Date();
   expiration.setDate(expiration.getDate() + trackingCategoryExpiration);
-  return {
-    expires: expiration,
-  };
+  return expiration;
 };
 
 export default setExpiryForCookie;

--- a/packages/cookie-manager/src/utils/setExpiryForCookie.ts
+++ b/packages/cookie-manager/src/utils/setExpiryForCookie.ts
@@ -1,0 +1,34 @@
+import { CATEGORY_EXPIRATION_DAYS } from '../constants';
+import { Config } from '../types';
+import getTrackerCategory from './getTrackerCategory';
+import trackerMatches from './trackerMatches';
+
+const setExpiryForCookie = (cookieName: string, config: Config) => {
+  const trackingCategory = getTrackerCategory(cookieName, config);
+  if (!trackingCategory) {
+    return undefined;
+  }
+
+  // if cookie has an expiry, set the expiry to that
+  const cookieConfig = trackingCategory.trackers.find((tracker) =>
+    trackerMatches(tracker, cookieName)
+  );
+
+  if (cookieConfig && cookieConfig.expiry) {
+    return {
+      expires: cookieConfig.expiry,
+    };
+  }
+  // if cookie is in a category with an expiry, set the expiry to that
+  const trackingCategoryExpiration = CATEGORY_EXPIRATION_DAYS[trackingCategory.id];
+  if (!trackingCategoryExpiration) {
+    return undefined;
+  }
+  const expiration = new Date();
+  expiration.setDate(expiration.getDate() + trackingCategoryExpiration);
+  return {
+    expires: expiration,
+  };
+};
+
+export default setExpiryForCookie;

--- a/packages/cookie-manager/src/utils/setExpiryForCookie.ts
+++ b/packages/cookie-manager/src/utils/setExpiryForCookie.ts
@@ -1,4 +1,4 @@
-import { CATEGORY_EXPIRATION_DAYS } from '../constants';
+import { ONE_DAY_IN_MILLISECONDS } from '../constants';
 import { Config } from '../types';
 import getTrackerCategory from './getTrackerCategory';
 import trackerMatches from './trackerMatches';
@@ -18,22 +18,22 @@ const setExpiryForCookie = (cookieName: string, config: Config) => {
     return undefined;
   }
 
+  const expiration = new Date();
+
   // if its a session cookie, do not set an expiry
   if (cookieConfig && cookieConfig.sessionCookie) {
     return undefined;
   }
 
   if (cookieConfig && cookieConfig.expiry) {
-    return cookieConfig.expiry;
+    return new Date(expiration.getTime() + cookieConfig.expiry * ONE_DAY_IN_MILLISECONDS);
   }
-  // if cookie is in a category with an expiry, set the expiry to that
-  const trackingCategoryExpiration = CATEGORY_EXPIRATION_DAYS[trackingCategory.id];
-  if (!trackingCategoryExpiration) {
-    return undefined;
+
+  if (trackingCategory) {
+    return new Date(expiration.getTime() + trackingCategory.expiry * ONE_DAY_IN_MILLISECONDS);
   }
-  const expiration = new Date();
-  expiration.setDate(expiration.getDate() + trackingCategoryExpiration);
-  return expiration;
+
+  return undefined;
 };
 
 export default setExpiryForCookie;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6692,8 +6692,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+wrap-ansi-cjs@7.0.0, "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
**What changed? Why?**

- Updated cookie config to include retention durations at both category and cookie levels.
- Introduced an optional boolean field `sessionCookie` in cookie config to accommodate session cookies.
- Implemented a setExpiryForCookie hook that adjusts the cookie's expiration in the following manner:
  - If the sessionCookie parameter is enabled, the expiry is set to session
  - If an expiry is specified at the cookie level, it takes precedence; otherwise, the expiry is derived from the category's expiration setting.

**Notes to reviewers**

**How has it been tested?**
- Unit tests
- Local testing