### PR TITLE
Enforce Apple App Tracking Transparency (ATT) Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,18 @@ It can manage four different types of first-party client side cookies:
 
 ## Getting Started
 
-This repo uses a yarn workspace. To get started, run:
+This repo uses a yarn workspace. To get started with the example app:
 
 ```shell
-# Install Dependencies
+cd /path/to/coinbase/cb-cookie-manager
+
+# Install Dependencies and Build Packages
 yarn install
+yarn build
 
-# To lint all files
-yarn lint
-
-# To run tests
-yarn test
+# Run Example App
+cd /path/to/coinbase/cb-cookie-manager/example/app
+yarn dev
 ```
 
 ## Packages

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@coinbase/cookie-banner": "1.0.3",
-    "@coinbase/cookie-manager": "1.1.1",
+    "@coinbase/cookie-manager": "1.1.2",
     "next": "14.0.0",
     "react": "^18",
     "react-dom": "^18"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "yarn workspaces run test"
   },
   "workspaces": [
-    "packages/*",
+    "packages/cookie-manager",
+    "packages/cookie-banner",
     "apps/example"
   ],
   "devDependencies": {

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^18.1.0"
   },
   "dependencies": {
-    "@coinbase/cookie-manager": "1.1.1",
+    "@coinbase/cookie-manager": "1.1.2",
     "react-intl": "^6.5.1",
     "styled-components": "^5.3.6"
   }

--- a/packages/cookie-manager/CHANGELOG.md
+++ b/packages/cookie-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.2 (02/26/2024)
+
+#### 🚀 Updates
+
+- Remove check for `is_mobile_app` from URL parameter from a WebView and use `app_tracking_transparency_enabled` to persist `is_mobile_app` cookie. This implementation is used to honor the Apple Do Not Track (DNT) configuration from a users' device instead of disabling cookies solely because the request is coming from a mobile device.
+
 ## 1.1.1 (01/05/2024)
 
 #### Bug

--- a/packages/cookie-manager/package.json
+++ b/packages/cookie-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cookie-manager",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Coinbase Cookie Manager",
   "main": "dist/index.js",
   "license": "Apache-2.0",
@@ -26,8 +26,6 @@
     "wrap-ansi-cjs": "7.0.0"
   },
   "dependencies": {
-    "@coinbase/cookie-banner": "1.0.1",
-    "@coinbase/cookie-manager": "1.1.0",
     "js-cookie": "^3.0.5"
   }
 }

--- a/packages/cookie-manager/src/hooks/useSavedTrackingPreference.ts
+++ b/packages/cookie-manager/src/hooks/useSavedTrackingPreference.ts
@@ -8,14 +8,14 @@ import {
 import { useCookie } from '../CookieContext';
 import { useTrackingManager } from '../TrackingManagerContext';
 import { Region, TrackingCategory, TrackingPreference } from '../types';
-import { getIsMobileAppFromQueryParams } from '../utils/persistMobileAppPreferences';
+import { getAppTrackingTransparencyFromQueryParams } from '../utils/persistMobileAppPreferences';
 
 export const useSavedTrackingPreferenceFromMobileApp = (): TrackingPreference | undefined => {
   const { region } = useTrackingManager();
 
   const [isMobileAppFromCookie] = useCookie(IS_MOBILE_APP);
 
-  const isMobileAppFromQueryParams = useMemo(() => getIsMobileAppFromQueryParams(), []);
+  const isMobileAppFromQueryParams = useMemo(() => getAppTrackingTransparencyFromQueryParams(), []);
 
   const isMobileApp = isMobileAppFromCookie || isMobileAppFromQueryParams;
 

--- a/packages/cookie-manager/src/index.ts
+++ b/packages/cookie-manager/src/index.ts
@@ -16,6 +16,6 @@ export { default as getDefaultTrackingPreference } from './utils/getDefaultTrack
 export { getDomainWithoutSubdomain } from './utils/getDomain';
 export { default as isOptOut } from './utils/isOptOut';
 export {
-  getIsMobileAppFromQueryParams,
+  getAppTrackingTransparencyFromQueryParams,
   persistMobileAppPreferences,
 } from './utils/persistMobileAppPreferences';

--- a/packages/cookie-manager/src/utils/persistMobileAppPreferences.ts
+++ b/packages/cookie-manager/src/utils/persistMobileAppPreferences.ts
@@ -1,8 +1,8 @@
 /*
- * The purpose here is to allow the iOS/Android app to send a is_mobile_app=true
- * parameter that should indicate to the web surfaces not to show the
- * cookie banner
- *
+ * From the iOS app, the `Do Not Track` preference from the app should be read and
+ * a `app_tracking_transparency_enabled=true` URL parameter is set to indicate the
+ * app tracking pereferences. The setting is then persisted in a cookie to honor the
+ * user preference for when a WebView is opened from within the mobile app.
  */
 
 import { IS_MOBILE_APP } from '../constants';
@@ -10,7 +10,7 @@ import { getDomainWithoutSubdomain } from './getDomain';
 
 export function persistMobileAppPreferences() {
   try {
-    const isMobileApp = getIsMobileAppFromQueryParams();
+    const isMobileApp = getAppTrackingTransparencyFromQueryParams();
     if (isMobileApp) {
       document.cookie = `${IS_MOBILE_APP}=true; domain=${getDomainWithoutSubdomain()}`;
     }
@@ -19,12 +19,12 @@ export function persistMobileAppPreferences() {
   }
 }
 
-export function getIsMobileAppFromQueryParams() {
+export function getAppTrackingTransparencyFromQueryParams() {
   try {
     const params = new URLSearchParams(window.location.search);
-    const isWebView = params.get('webview') === 'true';
-    const isMobileApp = params.get(IS_MOBILE_APP) === 'true';
-    return Boolean(isWebView || isMobileApp);
+
+    const appTrackingTransparency = params.get('app_tracking_transparency_enabled') === 'true';
+    return Boolean(appTrackingTransparency);
   } catch (e) {
     // Ignore, we are not in a browser.
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@coinbase/cookie-manager@1.1.2":
+  version "1.1.1"
+  dependencies:
+    js-cookie "^3.0.5"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -6693,6 +6698,7 @@ which@^2.0.1:
     isexe "^2.0.0"
 
 wrap-ansi-cjs@7.0.0, "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
**What changed? Why?**

- Remove check for `is_mobile_app` from URL parameter from a WebView and use `app_tracking_transparency_enabled` to persist `is_mobile_app` cookie. This implementation is used to honor the Apple Do Not Track (DNT) configuration from a users' device instead of disabling cookies solely because the request is coming from a mobile device.

**Notes to reviewers**
@Sneh1999 few action items to iterate on:

- Build out Github Actions auto-release process.
- Have prior unit test errors that need to be cleaned up. 

**How has it been tested?**

`app_tracking_transparency_enabled` URL Parameter False
![tracking_disabled](https://github.com/coinbase/cb-cookie-manager/assets/25240077/19f7d823-785f-4120-a16b-706175e7d46b)

`app_tracking_transparency_enabled` URL Parameter True
![tracking_enabled](https://github.com/coinbase/cb-cookie-manager/assets/25240077/bcff039d-ac7b-4f35-a67e-8f1b0aad7a23)

