### PR TITLE
@coinbase/cookie-banner v1.0.4

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -11,7 +11,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "@coinbase/cookie-banner": "1.0.3",
+    "@coinbase/cookie-banner": "1.0.4",
     "@coinbase/cookie-manager": "1.1.2",
     "next": "14.0.0",
     "react": "^18",

--- a/packages/cookie-banner/CHANGELOG.md
+++ b/packages/cookie-banner/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.0.2 (01/05/2024)
+## 1.0.4 (03/07/2024)
+
+#### Bug
+
+- Version pinned circular dependency was removed in the `coinbase/cookie-manager@1.1.2` release, `@coinbase/cookie-banner` is getting bumped to point to the updated release for `@coinbase/cookie-manager`.
+
+## 1.0.3 (01/05/2024)
 
 #### Bug
 

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cookie-banner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "license": "Apache-2.0",
   "scripts": {
@@ -26,7 +26,7 @@
     "react-dom": "^18.1.0"
   },
   "dependencies": {
-    "@coinbase/cookie-manager": "1.1.2",
+    "@coinbase/cookie-manager": "^1.1.2",
     "react-intl": "^6.5.1",
     "styled-components": "^5.3.6"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,9 +1077,40 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@coinbase/cookie-manager@1.1.2":
-  version "1.1.1"
+"@coinbase/cookie-banner@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@coinbase/cookie-banner/-/cookie-banner-1.0.1.tgz#90a10f13b62356baca41117cbcf98a20bff7e1cd"
+  integrity sha512-tVgNjNaSCC7nts/uju+vWkucWyXPSL4CaZflc5rkLuEKb7ZnY0otZnqDPRx0O4/0xLQ72tY9nw41/+HhTsKOqg==
   dependencies:
+    "@coinbase/cookie-manager" "^1.0.0"
+    react-intl "^6.5.1"
+    styled-components "^5.3.6"
+
+"@coinbase/cookie-banner@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@coinbase/cookie-banner/-/cookie-banner-1.0.3.tgz#a755e4ac9ffa0f3bfe22fc84ec4d88863ad82ad3"
+  integrity sha512-RMCyb42Ja4vxdZlN8tsFQaQgZUJwx7yvSFZeMnArQyHlKOjpzvJ+NCXY3G4aVYEGC0j86otsZ5Xe43F+qs2MYw==
+  dependencies:
+    "@coinbase/cookie-manager" "1.1.1"
+    react-intl "^6.5.1"
+    styled-components "^5.3.6"
+
+"@coinbase/cookie-manager@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@coinbase/cookie-manager/-/cookie-manager-1.1.0.tgz#3a47a89989953e0cb32b6b63445879252e42477b"
+  integrity sha512-r8UR7jSYxAPKIV7jSlqkmWfWi7kdcfMo7hJ0dV0FF2wMx1IIMU6V72BmuMpmn7Ov7HizAKtEcl/I/9fSWRVIQw==
+  dependencies:
+    "@coinbase/cookie-banner" "1.0.1"
+    "@coinbase/cookie-manager" "1.1.0"
+    js-cookie "^3.0.5"
+
+"@coinbase/cookie-manager@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@coinbase/cookie-manager/-/cookie-manager-1.1.1.tgz#f204ade281a2e2dccdf6e77baa7433cd054656a4"
+  integrity sha512-1fjLrWOyM2392eaDdgqIHlZHGuziRRzQZib3RuYSTdrX9z81muDc/oSvakb6VeDtfZkje0+3MHhnkSscaa5tUg==
+  dependencies:
+    "@coinbase/cookie-banner" "1.0.1"
+    "@coinbase/cookie-manager" "1.1.0"
     js-cookie "^3.0.5"
 
 "@cspotcode/source-map-support@^0.8.0":


### PR DESCRIPTION
**What changed? Why?**

- Nested dependencies were removed in @coinbase/cookie-manager in https://github.com/coinbase/cb-cookie-manager/pull/8. We are bumping `@coinbase/cookie-banner@1.0.3` since there are dependency issues with the latest release for `coinbase/cookie-manager@1.1.2`

```
npm list @coinbase/cookie-banner
example@1.0.0 /Users/yangkenneth/coinbase/cb-cookie-manager
└─┬ @coinbase/cookie-banner@1.0.3
  └─┬ @coinbase/cookie-manager@1.1.1
    ├── @coinbase/cookie-banner@1.0.1
    └─┬ @coinbase/cookie-manager@1.1.0
      └── @coinbase/cookie-banner@1.0.1 deduped
```

**Notes to reviewers**

**How has it been tested?**
- Build Updated Release for `@coinbase/cookie-banner` Locally
- Update Example App `package.json` to Local Path of `@coinbase/cookie-banner` and Install Dependencies with yarn.
```
  "dependencies": {
    "@coinbase/cookie-banner": "file:/path/to/cb-cookie-manager/packages/cookie-banner",
    "@coinbase/cookie-manager": "^1.1.2",
    "next": "14.0.0",
    "react": "^18",
    "react-dom": "^18"
  },
```

![Screenshot 2024-03-08 at 2 58 51 PM](https://github.com/coinbase/cb-cookie-manager/assets/25240077/45f1c300-4381-4333-8bf9-8b6c7e76f811)


