### PR TITLE
Wired up initial values support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ cd /path/to/coinbase/cb-cookie-manager/example/app
 yarn dev
 ```
 
+## Testing
+
+yarn test
+
 ## Packages
 
 - `@coinbase/cookie-manager`: Package that helps with managing first party client side cookies to adhere to CCPA and GDPR Cookie regulations. More information [here](./packages/cookie-manager/README.md)

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@coinbase/cookie-banner": "1.0.4",
-    "@coinbase/cookie-manager": "1.1.4",
+    "@coinbase/cookie-manager": "1.1.5",
     "next": "14.1.1",
     "react": "^18",
     "react-dom": "^18"

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^18.1.0"
   },
   "dependencies": {
-    "@coinbase/cookie-manager": "^1.1.4",
+    "@coinbase/cookie-manager": "^1.1.5",
     "react-intl": "^6.5.1",
     "styled-components": "^5.3.6"
   }

--- a/packages/cookie-manager/CHANGELOG.md
+++ b/packages/cookie-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.5 (06/12/2024)
+
+- Added support for initialCookieValues, initialGPCValue
+
 ## 1.1.4 (06/11/2024)
 
 - Updated next version from 14.0.0 to 14.1.1

--- a/packages/cookie-manager/README.md
+++ b/packages/cookie-manager/README.md
@@ -214,6 +214,10 @@ The provider must wrap the entire application and only be instantiated once. On 
 
 `log: (str: string, options?: Record<string, any>) => void`: Log function
 
+`initialCookieValues?:Record<string, string> `: Useful for server side rendering flows - setting of initial cookie values
+
+`initialGPCValue?:boolean`: Useful for server side rendering flows - honoring of Set-GPC header
+
 Example usage:
 
 ```typescript

--- a/packages/cookie-manager/package.json
+++ b/packages/cookie-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cookie-manager",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Coinbase Cookie Manager",
   "main": "dist/index.js",
   "license": "Apache-2.0",

--- a/packages/cookie-manager/src/types.ts
+++ b/packages/cookie-manager/src/types.ts
@@ -66,6 +66,8 @@ export type TrackingManagerDependencies = {
   config: Config;
   shadowMode?: boolean;
   log: LogFunction;
+  initialCookieValues?: Record<string, string>;
+  initialGPCValue?: boolean;
 };
 
 export type AdTrackingPreference = {

--- a/packages/cookie-manager/src/utils/applyGpcToAdPref.ts
+++ b/packages/cookie-manager/src/utils/applyGpcToAdPref.ts
@@ -1,20 +1,19 @@
 import { AdTrackingPreference, Region } from '../types';
+import getGpc from './getGpc';
 
 const applyGpcToAdPref = (
   region: Region,
-  preference: AdTrackingPreference
+  preference: AdTrackingPreference,
+  gpcHeader?: boolean
 ): AdTrackingPreference => {
   // We are only applying GPC in non-EU countries at this point
   if (region == Region.EU) {
     return preference;
   }
-
-  if (typeof window === 'undefined' || typeof window.navigator === 'undefined') {
-    return preference;
-  }
-
-  // If we lack GPC or it's set ot false we are done
-  if (!(window.navigator as any).globalPrivacyControl) {
+  // If the browser is has global privacy control enabled
+  // we will honor it
+  const gpc = getGpc(gpcHeader);
+  if (!gpc) {
     return preference;
   }
 

--- a/packages/cookie-manager/src/utils/applyGpcToCookiePref.ts
+++ b/packages/cookie-manager/src/utils/applyGpcToCookiePref.ts
@@ -1,20 +1,22 @@
 import { Region, TrackingCategory, TrackingPreference } from '../types';
+import getGpc from './getGpc';
 // { region: Region.DEFAULT,  consent: ['necessary', 'performance', 'functional', 'targeting'] }
-const applyGpcToCookiePref = (preference: TrackingPreference): TrackingPreference => {
+const applyGpcToCookiePref = (
+  preference: TrackingPreference,
+  gpcHeader?: boolean
+): TrackingPreference => {
   // We are only applying GPC in non-EU countries at this point
   if (preference.region == Region.EU) {
     return preference;
   }
 
-  // TODO: We want to support server side render flows
-  // where the user can set an initial value and indicate that gpc has been enabled
-  if (typeof window === 'undefined' || typeof window.navigator === 'undefined') {
+  // If the browser is has global privacy control enabled
+  // we will honor it
+  const gpc = getGpc(gpcHeader);
+  if (!gpc) {
     return preference;
   }
 
-  if (!(window.navigator as any).globalPrivacyControl) {
-    return preference;
-  }
   // If the user had opted in to GPC we want to honor it
   const categories = preference.consent.filter((cat) => cat !== TrackingCategory.TARGETING);
 

--- a/packages/cookie-manager/src/utils/getAllCookies.ts
+++ b/packages/cookie-manager/src/utils/getAllCookies.ts
@@ -25,6 +25,7 @@ export const deserializeCookies = (region: Region, cookies: Record<string, strin
   return parsedCookies;
 };
 
+// TODO clean up hydration
 export default function getAllCookies(region: Region, initialCookies?: Record<string, string>) {
   if (typeof window === 'undefined' && initialCookies) {
     return deserializeCookies(region, initialCookies);

--- a/packages/cookie-manager/src/utils/getGpc.test.ts
+++ b/packages/cookie-manager/src/utils/getGpc.test.ts
@@ -1,0 +1,17 @@
+import getGpc from './getGpc';
+
+describe('getGpc', () => {
+  it('honors navigator.globalPrivacyControl', () => {
+    (navigator as any).globalPrivacyControl = true;
+    expect(getGpc()).toEqual(true);
+  });
+
+  it('honors the passed header value when passed', () => {
+    (navigator as any).globalPrivacyControl = false;
+    expect(getGpc(true)).toEqual(true);
+  });
+
+  it('returns false by default', () => {
+    expect(getGpc()).toEqual(false);
+  });
+});

--- a/packages/cookie-manager/src/utils/getGpc.ts
+++ b/packages/cookie-manager/src/utils/getGpc.ts
@@ -1,0 +1,21 @@
+export function getGpc(gpcHeaderValue?: boolean): boolean {
+  const header = gpcHeaderValue == null ? false : gpcHeaderValue;
+
+  if (header) {
+    // honor the Set-GPC header if it's set to true
+    return true;
+  }
+
+  if (typeof window === 'undefined' || typeof window.navigator === 'undefined') {
+    // if we don't have access to the window.navigator return the header value
+    // if present, false otherwise
+    return header;
+  }
+
+  if (!(window.navigator as any).globalPrivacyControl) {
+    return false;
+  }
+  return true;
+}
+
+export default getGpc;


### PR DESCRIPTION
**What changed? Why?**
We were missing the ability to pass initial values on the provider.  This PR adds two:

- initialCookieValues
- initialGPCValue

These are useful for server side rendering flows where the values can be initialized ahead of client rendering.  Note that this PR does not yet refactor our liberal use of `typeof window === 'undefined' ` throughout the codebase.  We will dedicate a follow up PR to proper hydration.


**Notes to reviewers**

**How has it been tested?**
Added additional unit testing.