### PR TITLE
Include trackerMatches in the list of exported methods

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@coinbase/cookie-banner": "1.0.4",
-    "@coinbase/cookie-manager": "1.1.5",
+    "@coinbase/cookie-manager": "1.1.6",
     "next": "14.1.1",
     "react": "^18",
     "react-dom": "^18"

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^18.1.0"
   },
   "dependencies": {
-    "@coinbase/cookie-manager": "^1.1.5",
+    "@coinbase/cookie-manager": "^1.1.6",
     "react-intl": "^6.5.1",
     "styled-components": "^5.3.6"
   }

--- a/packages/cookie-manager/CHANGELOG.md
+++ b/packages/cookie-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.6 (07/17/2024)
+
+- Include trackerMatches in the list of exported methods
+
 ## 1.1.5 (06/12/2024)
 
 - Added support for initialCookieValues, initialGPCValue

--- a/packages/cookie-manager/README.md
+++ b/packages/cookie-manager/README.md
@@ -525,6 +525,28 @@ const SomeComponent = () => {
 }
 ```
 
+
+### trackingMatches
+
+Used for determining if the passed value matches the tracker criteria.
+
+This will match the if the value or regex produces a match on the passed value
+
+
+Example usage:
+
+```typescript
+import { trackerMatches } from '@coinbase/cookie-manager';
+
+const tracker: Tracker = {
+    id: 'id-regex',
+    type: TrackerType.COOKIE,
+    regex: 'id(?:_[a-f0-9]{32}|undefined)(?:.*)',
+};
+
+trackerMatches(tracker, 'id_ac7a5c3da45e3612b44543a702e42b01')
+```
+
 ## License
 
 Licensed under the Apache License. See [LICENSE](./LICENSE.md) for more information.

--- a/packages/cookie-manager/README.md
+++ b/packages/cookie-manager/README.md
@@ -526,7 +526,7 @@ const SomeComponent = () => {
 ```
 
 
-### trackingMatches
+### trackerMatches
 
 Used for determining if the passed value matches the tracker criteria.
 

--- a/packages/cookie-manager/package.json
+++ b/packages/cookie-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cookie-manager",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Coinbase Cookie Manager",
   "main": "dist/index.js",
   "license": "Apache-2.0",

--- a/packages/cookie-manager/src/index.ts
+++ b/packages/cookie-manager/src/index.ts
@@ -10,7 +10,6 @@ export { default as useSetTrackingPreference } from './hooks/useSetTrackingPrefe
 export { default as useTrackingPreference } from './hooks/useTrackingPreference';
 export { Provider } from './TrackingManagerContext';
 export { useTrackingManager } from './TrackingManagerContext';
-export { trackerMatches } from './utils/trackerMatches';
 export { Framework, Region, TrackerType, TrackingCategory, TrackingPreference } from './types';
 export { default as areCookiesEnabled } from './utils/areCookiesEnabled';
 export { default as getDefaultTrackingPreference } from './utils/getDefaultTrackingPreference';
@@ -20,3 +19,4 @@ export {
   getAppTrackingTransparencyFromQueryParams,
   persistMobileAppPreferences,
 } from './utils/persistMobileAppPreferences';
+export { default as trackerMatches } from './utils/trackerMatches';

--- a/packages/cookie-manager/src/index.ts
+++ b/packages/cookie-manager/src/index.ts
@@ -10,6 +10,7 @@ export { default as useSetTrackingPreference } from './hooks/useSetTrackingPrefe
 export { default as useTrackingPreference } from './hooks/useTrackingPreference';
 export { Provider } from './TrackingManagerContext';
 export { useTrackingManager } from './TrackingManagerContext';
+export { trackerMatches } from './utils/trackerMatches';
 export { Framework, Region, TrackerType, TrackingCategory, TrackingPreference } from './types';
 export { default as areCookiesEnabled } from './utils/areCookiesEnabled';
 export { default as getDefaultTrackingPreference } from './utils/getDefaultTrackingPreference';


### PR DESCRIPTION
**What changed? Why?**
Include trackerMatches in the list of exported methods.  Not logic changes just exposing this helper method.

**Notes to reviewers**

**How has it been tested?**
NA