### PR TITLE
Provide disableTimer option for testing

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@coinbase/cookie-banner": "1.0.4",
-    "@coinbase/cookie-manager": "1.1.7",
+    "@coinbase/cookie-manager": "1.1.8",
     "next": "14.1.1",
     "react": "^18",
     "react-dom": "^18"

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^18.1.0"
   },
   "dependencies": {
-    "@coinbase/cookie-manager": "^1.1.7",
+    "@coinbase/cookie-manager": "^1.1.8",
     "react-intl": "^6.5.1",
     "styled-components": "^5.3.6"
   }

--- a/packages/cookie-manager/CHANGELOG.md
+++ b/packages/cookie-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.8 (09/18/2024)
+
+- Introduce an optional `disableTimer` prop in `CookieProvider` to enhance testing flexibility and prevent conflicts with frequently used functions such as `runAllTimers` and `advanceTimersByTime`.
+
 ## 1.1.7 (07/17/2024)
 
 - Include Tracker in the list of exported types

--- a/packages/cookie-manager/package.json
+++ b/packages/cookie-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cookie-manager",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Coinbase Cookie Manager",
   "main": "dist/index.js",
   "license": "Apache-2.0",

--- a/packages/cookie-manager/src/CookieContext.tsx
+++ b/packages/cookie-manager/src/CookieContext.tsx
@@ -46,6 +46,7 @@ export const CookieProvider = ({ children }: Props) => {
     onPreferenceChange,
     initialCookieValues,
     initialGPCValue,
+    disableTimer,
   } = useTrackingManager();
 
   const POLL_INTERVAL = 500;
@@ -109,6 +110,12 @@ export const CookieProvider = ({ children }: Props) => {
         }
       };
 
+      // We provide a disableTimer option to avoid setting the interval and potentially introducing issues in timer related tests.
+      // This is meant to be used in testing only!
+      if (disableTimer == true) {
+        return () => {};
+      }
+
       checkCookies();
       // Call the function once before setting the interval
       const intervalId = setInterval(checkCookies, POLL_INTERVAL);
@@ -118,6 +125,7 @@ export const CookieProvider = ({ children }: Props) => {
       };
     }
   }, []);
+
   useEffect(() => {
     if (onPreferenceChange) {
       onPreferenceChange(trackingPreference);

--- a/packages/cookie-manager/src/types.ts
+++ b/packages/cookie-manager/src/types.ts
@@ -68,6 +68,10 @@ export type TrackingManagerDependencies = {
   log: LogFunction;
   initialCookieValues?: Record<string, string>;
   initialGPCValue?: boolean;
+  // We provide a disableTimer option to avoid setting an interval for
+  // periodically checking cookies. This is meant to be used in testing only to
+  // avoid issues with timer related tests.
+  disableTimer?: boolean;
 };
 
 export type AdTrackingPreference = {


### PR DESCRIPTION
**What changed? Why?**

Some consumers of cookie manager were reporting issues around introducing the package and seeing failed tests around timer usage. There are some documented alternatives like using `runOnlyPendingTimers` in place of functions like `runAllTimers` but this can quickly become cumbersome to maintain especially if there are multiple timing related functions that are being used and developers need to remember what workarounds are available for them to work well.

Therefore, this PR introduces a `disableTimer` option on CookieProvider to avoid setting a timer for periodically checking cookies. This option is meant to be used in testing only.

**Notes to reviewers**

**How has it been tested?**
